### PR TITLE
Edge refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+### How to Contribute to this repository
+
+We value contributions from the community and will do everything we
+can go get them reviewed in a timely fashion. If you have code to send
+our way or a bug to report:
+
+* **Contributing Code**: If you have new code or a bug fix, fork this
+  repo, create a logically-named branch, and [submit a PR against this
+  repo](https://github.com/helium/erlang-h3). Include a
+  write up of the PR with details on what it does.
+
+* **Reporting Bugs**: Open an issue [against this
+  repo](https://github.com/helium/erlang-h3/issues) with as
+  much detail as you can. At the very least you'll include steps to
+  reproduce the problem.
+
+This project is intended to be a safe, welcoming space for
+collaboration, and contributors are expected to adhere to the
+[Contributor Covenant Code of
+Conduct](http://contributor-covenant.org/).
+
+Above all, thank you for taking the time to be a part of the Helium
+community.

--- a/c_src/h3.c
+++ b/c_src/h3.c
@@ -633,11 +633,16 @@ erl_grid_distance(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
     }
 
     int64_t result = h3Distance(h3idx_src, h3idx_dest);
+    if (result < 0)
+    {
+        return enif_make_badarg(env);
+    }
+
     return enif_make_int64(env, result);
 }
 
 static ERL_NIF_TERM
-erl_get_h3_edge(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
+erl_get_unidirectional_edge(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
 {
     H3Index h3idx_origin;
     if (!get_h3idx(env, argv[0], &h3idx_origin))
@@ -652,10 +657,11 @@ erl_get_h3_edge(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
     }
 
     H3Index h3idx = getH3UnidirectionalEdge(h3idx_origin, h3idx_destination);
-    if (!h3UnidirectionalEdgeIsValid(h3idx))
+    if (h3idx == 0)
     {
         return enif_make_badarg(env);
     }
+
     return make_h3idx(env, h3idx);
 }
 
@@ -683,7 +689,7 @@ static ErlNifFunc nif_funcs[] =
      {"k_ring_distances", 2, erl_k_ring_distances, 0},
      {"max_k_ring_size", 1, erl_max_k_ring_size, 0},
      {"indices_are_neighbors", 2, erl_indices_are_neighbors, 0},
-     {"h3_edge", 2, erl_get_h3_edge, 0},
+     {"get_unidirectional_edge", 2, erl_get_unidirectional_edge, 0},
      {"grid_distance", 2, erl_grid_distance, 0}};
 
 #define ATOM(Id, Value)                                                        \

--- a/src/h3.erl
+++ b/src/h3.erl
@@ -23,7 +23,7 @@
          compact/1,
          uncompact/2,
          indices_are_neighbors/2,
-         h3_edge/2,
+         get_unidirectional_edge/2,
          grid_distance/2
         ]).
 
@@ -161,8 +161,8 @@ indices_are_neighbors(_, _) ->
     not_loaded(?LINE).
 
 %% @doc Returns the distance in grid cells between the two
-%% indexes. Returns a negative number if finding the distance
-%% failed. Finding the distance can fail because the two indexes are
+%% indexes. Throws a `badarg' if the distance can not be
+%% found. Finding the distance can fail because the two indexes are
 %% not comparable (different resolutions), too far apart, or are
 %% separated by pentagonal distortion.
 -spec grid_distance(h3index(), h3index()) -> integer().
@@ -171,8 +171,8 @@ grid_distance(_, _) ->
 
 %% @doc Returns a unidirectiol edge based on the given origin
 %% and destination.
--spec h3_edge(Origin::h3index(), Destination::h3index()) -> Edge::h3index().
-h3_edge(_, _) ->
+-spec get_unidirectional_edge(Origin::h3index(), Destination::h3index()) -> Edge::h3index().
+get_unidirectional_edge(_, _) ->
     not_loaded(?LINE).
 
 init() ->

--- a/test/h3_SUITE.erl
+++ b/test/h3_SUITE.erl
@@ -13,7 +13,7 @@
          h3_to_geo_boundary_test/1,
          hex_area_km2_decreasing_test/1,
          self_not_a_neighbor_test/1,
-         h3_edge_test/1,
+         get_unidirectional_edge_test/1,
          h3_of_geo_coord_test/1,
          k_ring_origin_index_test/1,
          k_ring_distance_origin_test/1,
@@ -32,7 +32,7 @@ all() ->
      h3_to_geo_constrain_test,
      hex_area_km2_decreasing_test,
      self_not_a_neighbor_test,
-     h3_edge_test,
+     get_unidirectional_edge_test,
      h3_of_geo_coord_test,
      k_ring_origin_index_test,
      k_ring_distance_origin_test,
@@ -111,10 +111,10 @@ self_not_a_neighbor_test(_Config) ->
     ok.
 
 
-h3_edge_test(Config) ->
-    ParisIndex = proplists:get_value(paris_index, Config), 
+get_unidirectional_edge_test(Config) ->
+    ParisIndex = proplists:get_value(paris_index, Config),
     NorthParisIndex = h3:from_geo({37.3715593, -122.0553238}, 7),
-    1401326775769759743 = h3:h3_edge(ParisIndex, NorthParisIndex),
+    1401326775769759743 = h3:get_unidirectional_edge(ParisIndex, NorthParisIndex),
     ok.
 
 h3_of_geo_coord_test(_Config) ->


### PR DESCRIPTION
In order to prevent future issues with bidirectional edges, `unidirectional` has been kept as part of the function name.